### PR TITLE
[FIXED] Changes for handling users whose profile page returns 500

### DIFF
--- a/myvip.lua
+++ b/myvip.lua
@@ -168,7 +168,7 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
     return wget.actions.ABORT
   end
 
-  if (status_code >= 200 and status_code <= 399) then
+  if (status_code >= 200 and status_code <= 399) or (status_code == 500 and string.match(url["url"], "^https?://[^/]*myvip%.com/profile%.php%?uid=")) then
     if string.match(url.url, "https://") then
       local newurl = string.gsub(url.url, "https://", "http://")
       downloaded[newurl] = true
@@ -177,7 +177,7 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
     end
   end
   
-  if status_code >= 500 or
+  if status_code > 500 or (status_code == 500 and not string.match(url["url"], "^https?://[^/]*myvip%.com/profile%.php%?uid=")) or
     (status_code >= 400 and status_code ~= 404) then
     io.stdout:write("Server returned "..http_stat.statcode.." ("..err.."). Sleeping.\n")
     io.stdout:flush()

--- a/pipeline.py
+++ b/pipeline.py
@@ -213,7 +213,6 @@ class WgetArgs(object):
         elif item_type == 'user':
             wget_args.append('http://myvip.com/profile.php?uid=' + item_value)
             wget_args.append('http://myvip.com/images.php?uid=' + item_value)
-            wget_args.append('http://myvip.com/search.php?act=dousercontacts&uid=' + item_value)
             wget_args.append('http://myvip.com/profile.php?act=getclubs&page=0&uid=' + item_value)
         else:
             raise Exception('Unknown item')

--- a/pipeline.py
+++ b/pipeline.py
@@ -38,7 +38,7 @@ if StrictVersion(seesaw.__version__) < StrictVersion("0.8.5"):
 # 2. prints the required version string
 WGET_LUA = find_executable(
     "Wget+Lua",
-    ["GNU Wget 1.14.lua.20130523-9a5c"],
+    ["GNU Wget 1.14.lua.20130523-9a5c", "GNU Wget 1.14.lua.20160530-955376b"],
     [
         "./wget-lua",
         "./wget-lua-warrior",
@@ -218,7 +218,7 @@ class WgetArgs(object):
         else:
             raise Exception('Unknown item')
         
-        #time.sleep(3)
+        time.sleep(3)
 
         myviplogin = requests.get('http://myvip.com/index.php')
         if not myviplogin.status_code == 200:

--- a/pipeline.py
+++ b/pipeline.py
@@ -38,7 +38,7 @@ if StrictVersion(seesaw.__version__) < StrictVersion("0.8.5"):
 # 2. prints the required version string
 WGET_LUA = find_executable(
     "Wget+Lua",
-    ["GNU Wget 1.14.lua.20130523-9a5c", "GNU Wget 1.14.lua.20160530-955376b"],
+    ["GNU Wget 1.14.lua.20130523-9a5c"],
     [
         "./wget-lua",
         "./wget-lua-warrior",
@@ -59,7 +59,7 @@ if not WGET_LUA:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = "20160730.01"
+VERSION = "20160823.01"
 USER_AGENT = 'ArchiveTeam'
 TRACKER_ID = 'myvip'
 TRACKER_HOST = 'tracker.archiveteam.org'
@@ -212,12 +212,14 @@ class WgetArgs(object):
                 wget_args.append(url)
         elif item_type == 'user':
             wget_args.append('http://myvip.com/profile.php?uid=' + item_value)
+            wget_args.append('http://myvip.com/images.php?uid=' + item_value)
+            wget_args.append('http://myvip.com/search.php?act=dousercontacts&uid=' + item_value)
             wget_args.append('http://myvip.com/profile.php?act=getclubs&page=0&uid=' + item_value)
         else:
             raise Exception('Unknown item')
         
-        time.sleep(3)
-        
+        #time.sleep(3)
+
         myviplogin = requests.get('http://myvip.com/index.php')
         if not myviplogin.status_code == 200:
             raise Exception('Something went wrong while connection to MyVIP.')


### PR DESCRIPTION
– Accepting response code 500 for profile pages (and only for them)
– Fetching images page (explicitly given in initial URLs), and as a consequence, the acquaintances page (they work even for 500ing users)
